### PR TITLE
Implementation of a simple Kakarot Server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.65"
-futures = "0.3.25"
-tarpc = { version = "0.30.0", features = ["tokio1"] }
-tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "macros"] }
+rocket = "0.5.0-rc.2" 
+rocket_codegen = "0.4.11"
+starknet = { git = "https://github.com/xJonathanLEI/starknet-rs" }
+eyre = "0.6.8"
+url = "2.3.1"
+tokio = "1.23.0"
+rocket_contrib = "0.4.11"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,98 @@
-#![allow(unused)]
+#![feature(proc_macro_hygiene, decl_macro)]
 
-use futures::{
-    future::{self, Ready},
-    prelude::*,
+#[macro_use] extern crate rocket;
+extern crate starknet;
+
+use starknet::{
+
+    core::{ types::{FieldElement,BlockId,CallFunction}},
+    providers::{SequencerGatewayProvider, Provider},
+    macros::{felt, selector},
+
 };
 
-use tarpc::{
-    client, context,
-    server::{self, incoming::Incoming, Channel},
-};
+// Good First RPCs
+//eth_blockNumber
+//eth_getCode
+//eth_getTransactionByHash
+//eth_sendTransaction
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    println!("👋 Hello, Kakarot!");
-    Ok(())
+#[get("/execute/<tx_bytecode>/<tx_calldata>")]
+async fn execute(   
+    tx_bytecode: String, 
+    tx_calldata: String) -> String {
+    println!("Transaction Calldata: {}",&tx_calldata);
+    call_execute(tx_bytecode,tx_calldata).await
+}
+
+// Call Execute function on Kakarot contract
+async fn call_execute(bytecode: String, calldata: String) -> String{
+
+    // Get the provider for goerli 2
+    let provider = SequencerGatewayProvider::starknet_alpha_goerli_2();
+
+    // Kakarot Contract Address on Goerli 2
+    let kakarot_token_address =
+        felt!("0x031ddf73d0285cc2f08bd4a2c93229f595f2f6e64b25846fc0957a2faa7ef7bb");
+
+    // Value for the transaction
+    let value = FieldElement::from_dec_str("00").unwrap(); 
+
+    // Apply the FieldElement::from_hex_be method to each hexadecimal string in the Vec
+    let bytecode_vec: Vec<FieldElement> = hex_string_to_felt_vec(bytecode);
+    let calldata_vec: Vec<FieldElement> = hex_string_to_felt_vec(calldata);
+
+    // Get bytecode and calldata length
+    let bytecode_len = FieldElement::from_dec_str(bytecode_vec.len().to_string().as_str()).unwrap();
+    let calldata_len =FieldElement::from_dec_str(calldata_vec.len().to_string().as_str()).unwrap();
+
+    // Create the calldata vector
+    let mut tx_calldata_vec = vec![value];
+    tx_calldata_vec.push(bytecode_len);
+    tx_calldata_vec.extend(bytecode_vec);
+    tx_calldata_vec.push(calldata_len);
+    tx_calldata_vec.extend(calldata_vec);
+
+    // Call Read Execute in Kakarot contract
+    let call_result = provider
+        .call_contract(
+            CallFunction {
+                contract_address: kakarot_token_address,
+                entry_point_selector: selector!("execute"),
+                calldata: tx_calldata_vec,
+            },
+            BlockId::Latest,
+        )
+        .await
+        .expect("failed to call contract");
+
+    // Return the result of the call in String
+    format!("{:?}", call_result)
+}
+
+// Convert a hexadecimal string to a vector of FieldElements
+fn hex_string_to_felt_vec(hex_string:String) -> Vec<FieldElement> {
+    // Split the String into groups of two characters
+    let hex_strings: Vec<String> = hex_string.chars().collect::<Vec<char>>()
+        .chunks(2)
+        .map(|chunk| {
+            // Concatenate the characters into a single String
+            chunk.iter().collect::<String>()
+        })
+        .collect();
+    
+    // Apply the Field::from_hex_be method to each hexadecimal string in the Vec
+    let felt_vec: Vec<FieldElement> = hex_strings
+        .into_iter()
+        .map(|hex_string| FieldElement::from_hex_be(&hex_string).unwrap())
+        .collect();        
+
+    felt_vec   
+}
+
+
+#[launch]
+
+fn rocket() -> _ {
+    rocket::build().mount("/kakarot/", routes![execute])
 }


### PR DESCRIPTION
Implemented a server that can call "execute" function of Kakarot in Goerli2 Tesnet.

To start the server, run "cargo run" on the root of the repo.

Features Implemented:

- hex_string_to_felt_vec function, which takes a Hex string  as argument and returns <FieldElement>
- call_execute function, which takes bytecode and calldata strings as arguments and call the "execute" in Kakarot.
- Simple rocket server with "kakarot/execute/<tx_bytecode>/<tx_calldata>" endpoint.