### PR TITLE
feat: get block transaction count by number

### DIFF
--- a/core/src/helpers.rs
+++ b/core/src/helpers.rs
@@ -61,14 +61,20 @@ pub fn ethers_block_id_to_starknet_block_id(
             })?;
             Ok(StarknetBlockId::Hash(address_felt))
         }
-        EthBlockId::Number(number) => match number {
-            BlockNumber::Latest => Ok(StarknetBlockId::Tag(BlockTag::Latest)),
-            BlockNumber::Finalized => Ok(StarknetBlockId::Tag(BlockTag::Latest)),
-            BlockNumber::Safe => Ok(StarknetBlockId::Tag(BlockTag::Latest)),
-            BlockNumber::Earliest => Ok(StarknetBlockId::Number(0)),
-            BlockNumber::Pending => Ok(StarknetBlockId::Tag(BlockTag::Pending)),
-            BlockNumber::Number(num) => Ok(StarknetBlockId::Number(num.as_u64())),
-        },
+        EthBlockId::Number(number) => ethers_block_number_to_starknet_block_id(number),
+    }
+}
+
+pub fn ethers_block_number_to_starknet_block_id(
+    block: BlockNumber,
+) -> Result<StarknetBlockId, LightClientError> {
+    match block {
+        BlockNumber::Latest => Ok(StarknetBlockId::Tag(BlockTag::Latest)),
+        BlockNumber::Finalized => Ok(StarknetBlockId::Tag(BlockTag::Latest)),
+        BlockNumber::Safe => Ok(StarknetBlockId::Tag(BlockTag::Latest)),
+        BlockNumber::Earliest => Ok(StarknetBlockId::Number(0)),
+        BlockNumber::Pending => Ok(StarknetBlockId::Tag(BlockTag::Pending)),
+        BlockNumber::Number(num) => Ok(StarknetBlockId::Number(num.as_u64())),
     }
 }
 

--- a/core/src/lightclient/mod.rs
+++ b/core/src/lightclient/mod.rs
@@ -266,6 +266,19 @@ impl StarknetClient for StarknetClientImpl {
         )))
     }
 
+    /// Get the number of transactions in a block given a block number.
+    /// The number of transactions in a block.
+    ///
+    /// # Arguments
+    ///
+    /// * `number(u64)` - The block number.
+    ///
+    /// # Returns
+    ///
+    ///  * `transaction_count(U256)` - The number of transactions.
+    ///
+    /// `Ok(Bytes)` if the operation was successful.
+    /// `Err(LightClientError)` if the operation failed.
     async fn block_transaction_count_by_number(
         &self,
         number: BlockNumber,

--- a/docs/methods/eth_getBlockTransactionCountByNumber.md
+++ b/docs/methods/eth_getBlockTransactionCountByNumber.md
@@ -1,0 +1,56 @@
+# eth_getBlockTransactionCountByNumber
+
+## Metadata
+
+- name: eth_getBlockTransactionCountByNumber
+- prefix: eth
+- state: ⚠️
+- [specification](https://github.com/ethereum/execution-apis/blob/main/src/eth/block.yaml#L43)
+- [issue]()
+
+## Specification Description
+
+Returns the number of transactions in a block matching the given block number.
+
+### Parameters
+
+- [BlockNumberOrTag](https://github.com/ethereum/execution-apis/blob/main/src/schemas/block.yaml#L102) - Block (required)
+
+### Returns
+
+- Transaction count - Uint
+
+## Kakarot Logic
+
+This method does not interact with the Kakarot contract or any other Starknet contract.
+It calls a Starknet JSON-RPC client and returns the number of transactions in a block matching the given block number.
+
+### Kakarot methods
+
+### Starknet methods
+
+- [starknet_getBlockWithTxs](https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json#L44)
+
+### Example
+
+Example call:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "eth_getBlockTransactionCountByNumber",
+  "params": ["latest"],
+  "id": 0
+}
+```
+
+Example responses:
+
+```json
+
+{
+  "jsonrpc":"2.0",
+  "result":"0x00000000000000000000000000000000000000000000000000000000000000df",
+  "id": 0
+}
+```

--- a/rpc-call-examples/getBlockTxCountByNumber.hurl
+++ b/rpc-call-examples/getBlockTxCountByNumber.hurl
@@ -1,0 +1,7 @@
+POST http://127.0.0.1:3030 
+Content-Type: application/json
+{
+    "jsonrpc":"2.0","method":"eth_getBlockTransactionCountByNumber","params":[
+        "latest"
+    ],"id":4
+}

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -315,7 +315,14 @@ impl EthApiServer for KakarotEthRpc {
         &self,
         _number: BlockNumber,
     ) -> Result<Option<U256>> {
-        todo!()
+        let transaction_count = self
+            .starknet_client
+            .block_transaction_count_by_number(_number)
+            .await?;
+        match transaction_count {
+            Some(transaction_count) => Ok(Some(transaction_count)),
+            None => Ok(None),
+        }
     }
 
     async fn block_uncles_count_by_hash(&self, _hash: H256) -> Result<U256> {


### PR DESCRIPTION
Implement getBlockTransactionCountByNumber

Time spent on this PR: 0.3

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

Unimplemented

Issue Number: N/A

# What is the new behavior?

Returns the number of transactions in a block given a block number.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
