### PR TITLE
Add import rules in rust fmt

### DIFF
--- a/core/src/client/constants.rs
+++ b/core/src/client/constants.rs
@@ -10,8 +10,7 @@ pub const STARKNET_NATIVE_TOKEN: &str =
     "2087021424722619777119509474943472645767659996348769578120564519014510906823";
 
 pub mod selectors {
-    use starknet::core::types::FieldElement;
-    use starknet::macros::selector;
+    use starknet::{core::types::FieldElement, macros::selector};
 
     pub const GET_STARKNET_CONTRACT_ADDRESS: FieldElement =
         selector!("get_starknet_contract_address");

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -48,8 +48,7 @@ use crate::client::{
     types::{Block, BlockTransactions, Header, Rich, RichBlock, Transaction as EtherTransaction},
 };
 use async_trait::async_trait;
-use mockall::automock;
-use mockall::predicate::str;
+use mockall::{automock, predicate::str};
 use reth_rpc_types::Index;
 pub mod constants;
 use constants::selectors::BYTECODE;
@@ -182,8 +181,9 @@ impl KakarotClientImpl {
         })
     }
 
-    /// Get the Ethereum address of a Starknet Kakarot smart-contract by calling `get_evm_address` on it.
-    /// If the contract's `get_evm_address` errors, returns the Starknet address sliced to 20 bytes to conform with EVM addresses formats.
+    /// Get the Ethereum address of a Starknet Kakarot smart-contract by calling `get_evm_address`
+    /// on it. If the contract's `get_evm_address` errors, returns the Starknet address sliced
+    /// to 20 bytes to conform with EVM addresses formats.
     ///
     /// ## Arguments
     ///
@@ -527,7 +527,6 @@ impl KakarotClient for KakarotClientImpl {
     /// ## Arguments
     /// * `ethereum_address` - The Ethereum address to convert to a Starknet address.
     /// * `starknet_block_id` - The block ID to use for the Starknet contract call.
-    ///
     async fn compute_starknet_address(
         &self,
         ethereum_address: Address,
@@ -785,15 +784,14 @@ impl KakarotClient for KakarotClientImpl {
     }
 
     /// Get the balance in Starknet's native token of a specific EVM address.
-    /// Reproduces the principle of Kakarot native coin by using Starknet's native ERC20 token (gas-utility token)
-    /// ### Arguments
+    /// Reproduces the principle of Kakarot native coin by using Starknet's native ERC20 token
+    /// (gas-utility token) ### Arguments
     /// * `ethereum_address` - The EVM address to get the balance of
     /// * `block_id` - The block to get the balance at
     ///
     /// ### Returns
-    /// * `Result<U256, KakarotClientError>` - The balance of the EVM address in Starknet's native token
-    ///
-    ///
+    /// * `Result<U256, KakarotClientError>` - The balance of the EVM address in Starknet's native
+    ///   token
     async fn balance(
         &self,
         ethereum_address: Address,

--- a/core/src/client/types.rs
+++ b/core/src/client/types.rs
@@ -1,6 +1,6 @@
-use reth_primitives::rpc::transaction::eip2930::AccessListItem;
-use reth_primitives::{Address, Bloom, Bytes, H256, H64, U256};
-use reth_primitives::{H512, U64};
+use reth_primitives::{
+    rpc::transaction::eip2930::AccessListItem, Address, Bloom, Bytes, H256, H512, H64, U256, U64,
+};
 use serde::{ser::Error, Deserialize, Serialize, Serializer};
 use std::{collections::BTreeMap, ops::Deref};
 

--- a/core/src/helpers.rs
+++ b/core/src/helpers.rs
@@ -217,7 +217,8 @@ pub fn vec_felt_to_bytes(felt_vec: Vec<FieldElement>) -> Bytes {
 /// ⚠️ BE CAREFUL ⚠️:
 /// In order to get the correct/true EVM address of a Kakarot smart contract or account,
 /// use the `client.get_evm_address`() method.
-/// `starknet_address_to_ethereum_address` is only used for Starknet addresses that do not have an EVM address equivalent.
+/// `starknet_address_to_ethereum_address` is only used for Starknet addresses that do not have an
+/// EVM address equivalent.
 pub fn starknet_address_to_ethereum_address(starknet_address: &FieldElement) -> Address {
     H160::from_slice(&starknet_address.to_bytes_be()[12..32])
 }

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -1,3 +1,4 @@
 mod tests {
-    // Refactor tests to use mocked Starknet client (with wiremock and then run src/client/mod.rs logic against it)
+    // Refactor tests to use mocked Starknet client (with wiremock and then run src/client/mod.rs
+    // logic against it)
 }

--- a/rpc/src/eth_rpc.rs
+++ b/rpc/src/eth_rpc.rs
@@ -1,9 +1,13 @@
-use jsonrpsee::core::{async_trait, RpcResult as Result};
-use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::{
+    core::{async_trait, RpcResult as Result},
+    proc_macros::rpc,
+};
 
 use jsonrpsee::types::error::CallError;
-use kakarot_rpc_core::client::{constants::selectors::CHAIN_ID, types::RichBlock, KakarotClient};
-use kakarot_rpc_core::helpers::{ethers_block_id_to_starknet_block_id, raw_calldata};
+use kakarot_rpc_core::{
+    client::{constants::selectors::CHAIN_ID, types::RichBlock, KakarotClient},
+    helpers::{ethers_block_id_to_starknet_block_id, raw_calldata},
+};
 use reth_primitives::{
     rpc::{transaction::eip2930::AccessListWithGasUsed, BlockId, BlockNumber, Bytes, H256},
     Address, Bytes as PrimitiveBytes, TransactionSigned, H64, U256, U64,
@@ -14,14 +18,14 @@ use reth_rpc_types::{
     TransactionRequest, Work,
 };
 use serde_json::Value;
-use starknet::core::types::FieldElement;
-use starknet::providers::jsonrpc::models::{BlockId as StarknetBlockId, BlockTag};
+use starknet::{
+    core::types::FieldElement,
+    providers::jsonrpc::models::{BlockId as StarknetBlockId, BlockTag},
+};
 
 use kakarot_rpc_core::client::types::{TokenBalances, Transaction as EtherTransaction};
 
 /// The RPC module for the Ethereum protocol required by Kakarot.
-///
-///
 pub struct KakarotEthRpc {
     pub kakarot_client: Box<dyn KakarotClient>,
 }
@@ -505,7 +509,8 @@ impl EthApiServer for KakarotEthRpc {
         _reward_percentiles: Option<Vec<f64>>,
     ) -> Result<FeeHistory> {
         // ⚠️ Experimental ⚠️
-        // This is a temporary implementation of the fee history API based on the idea that priority fee is estimated from former blocks
+        // This is a temporary implementation of the fee history API based on the idea that priority
+        // fee is estimated from former blocks
         const DEFAULT_REWARD: u64 = 10_u64;
         let block_count_usize = usize::from_str_radix(&_block_count.to_string(), 16).unwrap_or(1);
 

--- a/rpc/tests/testing_utils.rs
+++ b/rpc/tests/testing_utils.rs
@@ -1,7 +1,6 @@
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{serde_as, DeserializeAs, SerializeAs};
-use starknet::core::types::FieldElement;
-use starknet::providers::jsonrpc::JsonRpcMethod;
+use starknet::{core::types::FieldElement, providers::jsonrpc::JsonRpcMethod};
 
 impl SerializeAs<FieldElement> for UfeHex {
     fn serialize_as<S>(value: &FieldElement, serializer: S) -> Result<S::Ok, S::Error>

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+reorder_imports = true
+imports_granularity = "Crate"
+comment_width = 100
+wrap_comments = true
+use_field_init_shorthand = true


### PR DESCRIPTION
Time spent on this PR: 0.25

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

`cargo fmt` by default preserve the original structure written by the developer.

# What is the new behavior?

Using the `Crate` options will enforce a consistent usage of imports across the project

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Other information

Config partially taken from [reth](https://github.com/paradigmxyz/reth/blob/058349ecf86a41dd71b4916dc28cefa56eb8fb7e/rustfmt.toml)