### PR TITLE
Add workflow to build and push image to ghcr registry

### DIFF
--- a/.github/workflows/kakarot_rpc.yml
+++ b/.github/workflows/kakarot_rpc.yml
@@ -1,0 +1,28 @@
+name: RPC
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ghcr.io/sayajin-labs/kakarot-rpc/node:latest
+          context: .

--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@ kill_timeout = 5
 processes = []
 
 [build]
-image = "eliastazartes/kakarot-rpc:latest"
+image = "ghcr.io/sayajin-labs/kakarot-rpc/node:latest"
 
 [env]
 RUST_LOG = "debug"


### PR DESCRIPTION
Time spent on this PR: 0.1

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

The RPC Docker image is not built in the CI nor published in a sayajin-labs registry

# What is the new behavior?

Image is built on each merge on main and published in sayajin-labs's registry

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Other information
