### PR TITLE
fix: copy signature from calldata to tx field

### DIFF
--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -1268,8 +1268,23 @@ impl KakarotClient for KakarotClientImpl {
 
         let nonce = FieldElement::from(transaction.nonce());
 
-        // TODO: Provide signature
-        let signature = vec![];
+        let tx_signature = transaction.signature();
+        let r = FieldElement::from_byte_slice_be(&tx_signature.r.to_be_bytes::<32>()).map_err(
+            |_| {
+                KakarotClientError::OtherError(anyhow::anyhow!(
+                    "Kakarot send_transaction: r signature parameter recovery failed",
+                ))
+            },
+        )?;
+        let s = FieldElement::from_byte_slice_be(&tx_signature.s.to_be_bytes::<32>()).map_err(
+            |_| {
+                KakarotClientError::OtherError(anyhow::anyhow!(
+                    "Kakarot send_transaction: s signature parameter recovery failed",
+                ))
+            },
+        )?;
+        let v = FieldElement::from(tx_signature.v(Option::Some(CHAIN_ID)));
+        let signature = vec![r, s, v];
 
         let calldata = raw_starknet_calldata(self.kakarot_address, Bytes::from(bytes.0));
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Copy the signature from the calldata into the starknet transaction field.

<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.1 day

<!-- Which issue is this PR related to? -->

Closes #109 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Transactions are sent to Starknet with an empty signature field as EOA pulls the signature from the Starknet tx calldata.

# What is the new behavior?
Transactions are sent with a filled signature field.

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add signature to Starknet tx field.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

The PR does not currently include tests. Any guidance as to how to add testing would be appreciated.
